### PR TITLE
Fix race condition in flushDiscardStats function

### DIFF
--- a/value.go
+++ b/value.go
@@ -1393,9 +1393,13 @@ func (vlog *valueLog) updateDiscardStats(stats map[uint32]int64) error {
 
 // flushDiscardStats inserts discard stats into badger. Returns error on failure.
 func (vlog *valueLog) flushDiscardStats() error {
+	vlog.lfDiscardStats.Lock()
 	if len(vlog.lfDiscardStats.m) == 0 {
+		vlog.lfDiscardStats.Unlock()
 		return nil
 	}
+	vlog.lfDiscardStats.Unlock()
+
 	entries := []*Entry{{
 		Key:   y.KeyWithTs(lfDiscardStatsKey, 1),
 		Value: vlog.encodedDiscardStats(),


### PR DESCRIPTION
A couple of builds failed on teamcity with data race error.
See https://teamcity.dgraph.io/viewLog.html?buildId=16131

This PR fixes the data race in `flushDiscardStats` function.

(copied from https://github.com/dgraph-io/badger/commit/5caab82485132370bbb7c8ca1a1f15d018d399f3)